### PR TITLE
backend: fix path to run lint.sh

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,4 @@
-name: Lint
+name: Lint backend
 
 on:
   pull_request:
@@ -24,7 +24,7 @@ jobs:
           poetry-version: '1.8.3'
 
       - name: Install dependencies
-        run: poetry install
+        run: cd backend && poetry install
 
       - name: Lint
-        run: ./scripts/lint.sh
+        run: cd backend && ./scripts/lint.sh

--- a/backend/scripts/lint.sh
+++ b/backend/scripts/lint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euxo pipefail
 
-poetry run black apps/ tests/ settings/
-poetry run isort --profile hug --check --diff tests/
-poetry run flake8 apps/ tests/ settings/
-poetry run ruff check apps/ tests/ settings/ 
+poetry run black apps/ settings/
+poetry run isort apps/ settings/
+poetry run flake8 apps/ settings/
+poetry run ruff check apps/ settings/ 


### PR DESCRIPTION
- Add step to run lint in github actions

## Summary by Sourcery

Fix the path to execute the lint script in the GitHub Actions workflow and update the linting commands to exclude the tests directory.

Bug Fixes:
- Correct the path to run the lint script in the GitHub Actions workflow.

CI:
- Update the GitHub Actions workflow to run the linting process in the backend directory.